### PR TITLE
Save preview scroll position on update / reload

### DIFF
--- a/src/playground-preview.ts
+++ b/src/playground-preview.ts
@@ -137,6 +137,16 @@ export class PlaygroundPreview extends PlaygroundConnectedElement {
   @state()
   private _error?: TemplateResult;
 
+  /**
+   * The scroll position of the current preview in the iframe
+   */
+  @state()
+  private _scrollPosition = [0, 0];
+
+  setScroll = (scrollPosition: number[]) => {
+    this.iframe!.contentWindow?.scrollTo(scrollPosition[0], scrollPosition[1])
+  }
+
   constructor() {
     super();
     if (navigator.serviceWorker === undefined) {
@@ -256,6 +266,8 @@ export class PlaygroundPreview extends PlaygroundConnectedElement {
 
   reload = () => {
     const iframe = this.iframe;
+    iframe?.contentWindow?.scrollX ? this._scrollPosition[0] = iframe.contentWindow.scrollX : null
+    iframe?.contentWindow?.scrollY ? this._scrollPosition[1] = iframe.contentWindow.scrollY : null
     if (!iframe) {
       return;
     }
@@ -324,6 +336,7 @@ export class PlaygroundPreview extends PlaygroundConnectedElement {
       this._loading = false;
       this._loadedAtLeastOnce = true;
       this._showLoadingBar = false;
+      this.setScroll(this._scrollPosition)
     }
   }
 }


### PR DESCRIPTION
Stores preview scroll position so that it can be retained when the preview is regenerated as a result of changing the underlying HTML or reloading the preview

[Issue Ticket:](https://github.com/centrica-engineering/nucleus-playground/issues/159) : Note, the scope of this issue needs to be reduced, as the elements that deal with saving scroll position are managed in the nucleus-playground repository.